### PR TITLE
modified classifier.py to support weights parameters

### DIFF
--- a/intropyproject-classify-pet-images/classifier.py
+++ b/intropyproject-classify-pet-images/classifier.py
@@ -4,10 +4,14 @@ import torchvision.transforms as transforms
 from torch.autograd import Variable
 import torchvision.models as models
 from torch import __version__
+# Load pre-trained models using the 'weights' parameter to fix the The 'pretrained' parameter is deprecated warnings
+from torchvision.models import alexnet, AlexNet_Weights
+from torchvision.models import resnet18, ResNet18_Weights
+from torchvision.models import vgg16, VGG16_Weights
 
-resnet18 = models.resnet18(pretrained=True)
-alexnet = models.alexnet(pretrained=True)
-vgg16 = models.vgg16(pretrained=True)
+resnet18 = models.resnet18(weights=ResNet18_Weights.DEFAULT)
+alexnet = models.alexnet(weights=AlexNet_Weights.DEFAULT)
+vgg16 = models.vgg16(weights=VGG16_Weights.DEFAULT)
 
 models = {'resnet': resnet18, 'alexnet': alexnet, 'vgg': vgg16}
 


### PR DESCRIPTION
The changes to **classifier.py** add pre-trained weights parameter support and remove the deprecated pretrained=true flag when initializing the pre-trained CNN models. This will resolve issue #15.   

**Caveats and advantages of this change:**
1. It uses the Default weights for better performance by using the best available weights (currently an alias for IMAGENET1K_V2) resulting in an improved performance when  I timed the execution of check_images.py. 
2. by using _Weights.DEFAULT we ensure that the code does not break if weights may change across versions.
Check the following link for more information:
[https://pytorch.org/vision/stable/models.html#models-and-pre-trained-weights](url)  